### PR TITLE
Implement prometheus-manual interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.docs
+__pycache__
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,113 @@
+# Interface prometheus-manual
+
+This is a [Juju][] interface layer that enables a charm which provides manual
+or raw metric scraper job configuration stanzas for Prometheus 2.
+
+The format for the job configuration data can be found in the [Prometheus
+Configuration Docs][].  The job configuration will be included as an item
+under `scrape_configs` largely unchanged, except for two things:
+
+* To ensure uniqueness, the provided job name will have a UUID appended to it.
+* Because the CA cert must be written to disk separately from the config, any
+  `tls_config` sections will have their `ca_file` field values replaced with
+  the path to the file where the provided `ca_cert` data is written.
+
+# Example Usage
+
+First, you must define the relation endpoint in your charm's `metadata.yaml`:
+
+```yaml
+provides:
+  prometheus:
+    interface: prometheus-manual
+```
+
+Next, you must ensure the interface layer is included in your `layer.yaml`:
+
+```yaml
+includes:
+  - interface:prometheus-manual
+```
+
+Then, in your reactive code, add the following, modifying the job data as
+your charm needs:
+
+```python
+from charms.reactive import endpoint_from_flag
+
+
+@when('endpoint.prometheus.joined',
+      'tls.ca.available')
+def register_prometheus_jobs():
+    prometheus = endpoint_from_flag('endpoint.prometheus.joined')
+    tls = endpoint_from_flag('tls.ca.available')
+    prometheus.register_job(job_name='kubernetes-apiservers',
+                            ca_cert=tls.root_ca_cert,
+                            job_data={
+                                'kubernetes_sd_configs': [{'role': 'endpoints'}],
+                                'scheme': 'https',
+                                'tls_config': {'ca_file': '__ca_file__'},  # placeholder for saved filename
+                                'bearer_token': get_token('system:prometheus'),
+                            })
+    prometheus.register_job(job_name='kubernetes-nodes',
+                            ca_cert=tls.root_ca_cert,
+                            job_data={
+                                'kubernetes_sd_configs': [{'role': 'node'}],
+                                'scheme': 'https',
+                                'tls_config': {'ca_file': '__ca_file__'},  # placeholder for saved filename
+                                'bearer_token': get_token('system:prometheus'),
+                            })
+```
+
+<!-- charm-layer-docs generated reference -->
+
+# Reference
+
+* [common.md](common.md)
+  * [JobRequest](docs/common.md#jobrequest)
+    * [egress_subnets](docs/common.md#jobrequest-egress_subnets)
+    * [fromkeys](docs/common.md#jobrequest-fromkeys)
+    * [ingress_address](docs/common.md#jobrequest-ingress_address)
+    * [is_created](docs/common.md#jobrequest-is_created)
+    * [is_received](docs/common.md#jobrequest-is_received)
+    * [respond](docs/common.md#jobrequest-respond)
+    * [to_json](docs/common.md#jobrequest-to_json)
+  * [JobResponse](docs/common.md#jobresponse)
+    * [fromkeys](docs/common.md#jobresponse-fromkeys)
+* [provides.md](provides.md)
+  * [PrometheusManualProvides](docs/provides.md#prometheusmanualprovides)
+    * [all_departed_units](docs/provides.md#prometheusmanualprovides-all_departed_units)
+    * [all_joined_units](docs/provides.md#prometheusmanualprovides-all_joined_units)
+    * [all_units](docs/provides.md#prometheusmanualprovides-all_units)
+    * [endpoint_name](docs/provides.md#prometheusmanualprovides-endpoint_name)
+    * [is_joined](docs/provides.md#prometheusmanualprovides-is_joined)
+    * [joined](docs/provides.md#prometheusmanualprovides-joined)
+    * [manage_flags](docs/provides.md#prometheusmanualprovides-manage_flags)
+    * [register_job](docs/provides.md#prometheusmanualprovides-register_job)
+    * [relations](docs/provides.md#prometheusmanualprovides-relations)
+    * [requests](docs/provides.md#prometheusmanualprovides-requests)
+    * [responses](docs/provides.md#prometheusmanualprovides-responses)
+* [requires.md](requires.md)
+  * [PrometheusManualRequires](docs/requires.md#prometheusmanualrequires)
+    * [all_departed_units](docs/requires.md#prometheusmanualrequires-all_departed_units)
+    * [all_joined_units](docs/requires.md#prometheusmanualrequires-all_joined_units)
+    * [all_requests](docs/requires.md#prometheusmanualrequires-all_requests)
+    * [all_units](docs/requires.md#prometheusmanualrequires-all_units)
+    * [endpoint_name](docs/requires.md#prometheusmanualrequires-endpoint_name)
+    * [is_joined](docs/requires.md#prometheusmanualrequires-is_joined)
+    * [jobs](docs/requires.md#prometheusmanualrequires-jobs)
+    * [joined](docs/requires.md#prometheusmanualrequires-joined)
+    * [manage_flags](docs/requires.md#prometheusmanualrequires-manage_flags)
+    * [new_jobs](docs/requires.md#prometheusmanualrequires-new_jobs)
+    * [new_requests](docs/requires.md#prometheusmanualrequires-new_requests)
+    * [relations](docs/requires.md#prometheusmanualrequires-relations)
+
+<!-- /charm-layer-docs generated reference -->
+
+# Contact Information
+
+Maintainer: Cory Johns &lt;Cory.Johns@canonical.com&gt;
+
+
+[Juju]: https://jujucharms.com
+[Prometheus Configuration Docs]: https://prometheus.io/docs/prometheus/latest/configuration/configuration/

--- a/common.py
+++ b/common.py
@@ -34,7 +34,9 @@ class JobRequest(BaseRequest):
 
         if self.ca_cert:
             # cert has to be provided in a file, so we need to stash it on disk
-            cert_dir = Path('/etc/prometheus-manual-interface/certs')
+            # FIXME: this should probably be provided by the charm, but it also
+            # needs to be populated into the JSON data
+            cert_dir = Path('/var/snap/prometheus/common/certs')
             cert_dir.mkdir(parents=True, exist_ok=True)
 
             # use a hash of the cert data rather than the request ID so that we

--- a/common.py
+++ b/common.py
@@ -1,7 +1,5 @@
 import json
 from copy import deepcopy
-from pathlib import Path
-from hashlib import sha1
 
 from charms.reactive import BaseRequest, BaseResponse, Field
 
@@ -21,40 +19,33 @@ class JobRequest(BaseRequest):
 
     ca_cert = Field('Cert data for the CA used to validate connections.')
 
-    def to_json(self):
+    def to_json(self, ca_file=None):
         """
         Render the job request to JSON string which can be included directly
         into Prometheus config.
 
         Keys will be sorted in the rendering to ensure a stable ordering for
         comparisons to detect changes.
+
+        If `ca_file` is given, it will be used to replace the value of any
+        `ca_file` fields in the job.  The charm should ensure that the
+        request's `ca_cert` data is writen to that path prior to calling this
+        method.
         """
         job_data = deepcopy(self.job_data)  # make a copy we can modify
         job_data['job_name'] = '{}-{}'.format(self.job_name, self.request_id)
 
-        if self.ca_cert:
-            # cert has to be provided in a file, so we need to stash it on disk
-            # FIXME: this should probably be provided by the charm, but it also
-            # needs to be populated into the JSON data
-            cert_dir = Path('/var/snap/prometheus/common/certs')
-            cert_dir.mkdir(parents=True, exist_ok=True)
-
-            # use a hash of the cert data rather than the request ID so that we
-            # can detect changes to the data via the filename
-            cert_hash = sha1(self.ca_cert.encode('utf8')).hexdigest()
-            cert_path = cert_dir / '{}-{}.crt'.format(self.job_name, cert_hash)
-            cert_path.write_text(self.ca_cert + '\n')
-
+        if ca_file:
             for key, value in job_data.items():
                 # update the cert path at the job level
                 if key == 'tls_config':
-                    value['ca_file'] = str(cert_path)
+                    value['ca_file'] = str(ca_file)
 
                 # update the cert path at the SD config level
                 if key.endswith('_sd_configs'):
                     for sd_config in value:
                         if 'ca_file' in sd_config.get('tls_config', {}):
-                            sd_config['tls_config']['ca_file'] = str(cert_path)
+                            sd_config['tls_config']['ca_file'] = str(ca_file)
 
         return json.dumps(job_data, sort_keys=True)
 

--- a/common.py
+++ b/common.py
@@ -1,0 +1,64 @@
+import json
+from copy import deepcopy
+from pathlib import Path
+from hashlib import sha1
+
+from charms.reactive import BaseRequest, BaseResponse, Field
+
+
+class JobResponse(BaseResponse):
+    success = Field('Whether or not the registration succeeded')
+    reason = Field('If failed, a description of why')
+
+
+class JobRequest(BaseRequest):
+    RESPONSE_CLASS = JobResponse
+
+    job_name = Field('Desired name for the job.  To ensure uniqueness, the '
+                     'the request ID will be appended to the final job name.')
+
+    job_data = Field('Config data for the job.')
+
+    ca_cert = Field('Cert data for the CA used to validate connections.')
+
+    def to_json(self):
+        """
+        Render the job request to JSON string which can be included directly
+        into Prometheus config.
+
+        Keys will be sorted in the rendering to ensure a stable ordering for
+        comparisons to detect changes.
+        """
+        job_data = deepcopy(self.job_data)  # make a copy we can modify
+        job_data['job_name'] = '{}-{}'.format(self.job_name, self.request_id)
+
+        if self.ca_cert:
+            # cert has to be provided in a file, so we need to stash it on disk
+            cert_dir = Path('/etc/prometheus-manual-interface/certs')
+            cert_dir.mkdir(parents=True, exist_ok=True)
+
+            # use a hash of the cert data rather than the request ID so that we
+            # can detect changes to the data via the filename
+            cert_hash = sha1(self.ca_cert.encode('utf8')).hexdigest()
+            cert_path = cert_dir / '{}-{}.crt'.format(self.job_name, cert_hash)
+            cert_path.write_text(self.ca_cert + '\n')
+
+            for key, value in job_data.items():
+                # update the cert path at the job level
+                if key == 'tls_config':
+                    value['ca_file'] = str(cert_path)
+
+                # update the cert path at the SD config level
+                if key.endswith('_sd_configs'):
+                    for sd_config in value:
+                        if 'ca_file' in sd_config.get('tls_config', {}):
+                            sd_config['tls_config']['ca_file'] = str(cert_path)
+
+        return json.dumps(job_data, sort_keys=True)
+
+    def respond(self, success, reason=None):
+        """
+        Acknowledge this request, and indicate success or failure with an
+        optional explanation.
+        """
+        super().respond(success=success, reason=reason)

--- a/docs/common.md
+++ b/docs/common.md
@@ -1,0 +1,62 @@
+# <a id="jobrequest"></a>`class JobRequest(BaseRequest)`
+
+Base class for requests using the request / response pattern.
+
+Subclasses **must** set the ``RESPONSE_CLASS`` attribute to a subclass of
+the :class:`BaseResponse` which defines the fields that the response will
+use.  They must also define additional attributes as :class:`Field`s.
+
+For example::
+
+    class TLSResponse(BaseResponse):
+        key = Field('Private key for the cert')
+        cert = Field('Public cert info')
+
+
+    class TLSRequest(BaseRequest):
+        RESPONSE_CLASS = TLSResponse
+
+        common_name = Field('Common Name (CN) for the cert to be created')
+        sans = Field('List of Subject Alternative Names (SANs)')
+
+## <a id="jobrequest-egress_subnets"></a>`egress_subnets`
+
+Subnets over which network traffic to the requester will flow.
+
+## <a id="jobrequest-fromkeys"></a>`None`
+
+Returns a new dict with keys from iterable and values equal to value.
+
+## <a id="jobrequest-ingress_address"></a>`ingress_address`
+
+Address to use if a connection to the requester is required.
+
+## <a id="jobrequest-is_created"></a>`is_created`
+
+Whether this request was created by this side of the relation.
+
+## <a id="jobrequest-is_received"></a>`is_received`
+
+Whether this request was received by the other side of the relation.
+
+## <a id="jobrequest-respond"></a>`def respond(self, success, reason=None)`
+
+Acknowledge this request, and indicate success or failure with an
+optional explanation.
+
+## <a id="jobrequest-to_json"></a>`def to_json(self)`
+
+Render the job request to JSON string which can be included directly
+into Prometheus config.
+
+Keys will be sorted in the rendering to ensure a stable ordering for
+comparisons to detect changes.
+
+# <a id="jobresponse"></a>`class JobResponse(BaseResponse)`
+
+Base class for responses using the request / response pattern.
+
+## <a id="jobresponse-fromkeys"></a>`None`
+
+Returns a new dict with keys from iterable and values equal to value.
+

--- a/docs/provides.md
+++ b/docs/provides.md
@@ -1,0 +1,119 @@
+# <a id="prometheusmanualprovides"></a>`class PrometheusManualProvides(RequesterEndpoint)`
+
+Base class for Endpoints that create requests in the request / response
+pattern.
+
+Subclasses **must** set the ``REQUEST_CLASS`` attribute to a subclass
+of :class:`BaseRequest` which defines the fields the request will use.
+
+## <a id="prometheusmanualprovides-all_departed_units"></a>`all_departed_units`
+
+Collection of all units that were previously part of any relation on
+this endpoint but which have since departed.
+
+This collection is persistent and mutable.  The departed units will
+be kept until they are explicitly removed, to allow for reasonable
+cleanup of units that have left.
+
+Example: You need to run a command each time a unit departs the relation.
+
+.. code-block:: python
+
+    @when('endpoint.{endpoint_name}.departed')
+    def handle_departed_unit(self):
+        for name, unit in self.all_departed_units.items():
+            # run the command to remove `unit` from the cluster
+            #  ..
+        self.all_departed_units.clear()
+        clear_flag(self.expand_name('departed'))
+
+Once a unit is departed, it will no longer show up in
+:attr:`all_joined_units`.  Note that units are considered departed as
+soon as the departed hook is entered, which differs slightly from how
+the Juju primitives behave (departing units are still returned from
+``related-units`` until after the departed hook is complete).
+
+This collection is a :class:`KeyList`, so can be used as a mapping to
+look up units by their unit name, or iterated or accessed by index.
+
+## <a id="prometheusmanualprovides-all_joined_units"></a>`all_joined_units`
+
+A list view of all the units of all relations attached to this
+:class:`~charms.reactive.endpoints.Endpoint`.
+
+This is actually a
+:class:`~charms.reactive.endpoints.CombinedUnitsView`, so the units
+will be in order by relation ID and then unit name, and you can access a
+merged view of all the units' data as a single mapping.  You should be
+very careful when using the merged data collections, however, and
+consider carefully what will happen when the endpoint has multiple
+relations and multiple remote units on each.  It is probably better to
+iterate over each unit and handle its data individually.  See
+:class:`~charms.reactive.endpoints.CombinedUnitsView` for an
+explanation of how the merged data collections work.
+
+Note that, because a given application might be related multiple times
+on a given endpoint, units may show up in this collection more than
+once.
+
+## <a id="prometheusmanualprovides-all_units"></a>`all_units`
+
+.. deprecated:: 0.6.1
+   Use :attr:`all_joined_units` instead
+
+## <a id="prometheusmanualprovides-endpoint_name"></a>`endpoint_name`
+
+Relation name of this endpoint.
+
+## <a id="prometheusmanualprovides-is_joined"></a>`is_joined`
+
+Whether this endpoint has remote applications attached to it.
+
+## <a id="prometheusmanualprovides-joined"></a>`joined`
+
+.. deprecated:: 0.6.3
+   Use :attr:`is_joined` instead
+
+## <a id="prometheusmanualprovides-manage_flags"></a>`def manage_flags(self)`
+
+Method that subclasses can override to perform any flag management
+needed during startup.
+
+This will be called automatically after the framework-managed automatic
+flags have been updated.
+
+## <a id="prometheusmanualprovides-register_job"></a>`def register_job(self, job_name, job_data, ca_cert=None)`
+
+Register a manual job.
+
+The job data should be the (unserialized) data defining the job.
+
+To ensure uniqueness, a UUID will be added to the job name, and it will
+be injected into the job data.
+
+If a CA cert is given, the value of any ca_file field in the job data
+will be replaced with a filename after the CA cert data is written, so
+a placeholder value should be used.
+
+## <a id="prometheusmanualprovides-relations"></a>`relations`
+
+Collection of :class:`Relation` instances that are established for
+this :class:`Endpoint`.
+
+This is a :class:`KeyList`, so it can be iterated and indexed as a list,
+or you can look up relations by their ID.  For example::
+
+    rel0 = endpoint.relations[0]
+    assert rel0 is endpoint.relations[rel0.relation_id]
+    assert all(rel is endpoint.relations[rel.relation_id]
+               for rel in endpoint.relations)
+    print(', '.join(endpoint.relations.keys()))
+
+## <a id="prometheusmanualprovides-requests"></a>`requests`
+
+A list of all requests which have been submitted.
+
+## <a id="prometheusmanualprovides-responses"></a>`responses`
+
+A list of all responses which have been received.
+

--- a/docs/requires.md
+++ b/docs/requires.md
@@ -1,0 +1,117 @@
+# <a id="prometheusmanualrequires"></a>`class PrometheusManualRequires(ResponderEndpoint)`
+
+Base class for Endpoints that respond to requests in the request / response
+pattern.
+
+Subclasses **must** set the ``REQUEST_CLASS`` attribute to a subclass
+of :class:`BaseRequest` which defines the fields the request will use.
+
+## <a id="prometheusmanualrequires-all_departed_units"></a>`all_departed_units`
+
+Collection of all units that were previously part of any relation on
+this endpoint but which have since departed.
+
+This collection is persistent and mutable.  The departed units will
+be kept until they are explicitly removed, to allow for reasonable
+cleanup of units that have left.
+
+Example: You need to run a command each time a unit departs the relation.
+
+.. code-block:: python
+
+    @when('endpoint.{endpoint_name}.departed')
+    def handle_departed_unit(self):
+        for name, unit in self.all_departed_units.items():
+            # run the command to remove `unit` from the cluster
+            #  ..
+        self.all_departed_units.clear()
+        clear_flag(self.expand_name('departed'))
+
+Once a unit is departed, it will no longer show up in
+:attr:`all_joined_units`.  Note that units are considered departed as
+soon as the departed hook is entered, which differs slightly from how
+the Juju primitives behave (departing units are still returned from
+``related-units`` until after the departed hook is complete).
+
+This collection is a :class:`KeyList`, so can be used as a mapping to
+look up units by their unit name, or iterated or accessed by index.
+
+## <a id="prometheusmanualrequires-all_joined_units"></a>`all_joined_units`
+
+A list view of all the units of all relations attached to this
+:class:`~charms.reactive.endpoints.Endpoint`.
+
+This is actually a
+:class:`~charms.reactive.endpoints.CombinedUnitsView`, so the units
+will be in order by relation ID and then unit name, and you can access a
+merged view of all the units' data as a single mapping.  You should be
+very careful when using the merged data collections, however, and
+consider carefully what will happen when the endpoint has multiple
+relations and multiple remote units on each.  It is probably better to
+iterate over each unit and handle its data individually.  See
+:class:`~charms.reactive.endpoints.CombinedUnitsView` for an
+explanation of how the merged data collections work.
+
+Note that, because a given application might be related multiple times
+on a given endpoint, units may show up in this collection more than
+once.
+
+## <a id="prometheusmanualrequires-all_requests"></a>`all_requests`
+
+A list of all requests, including ones which have been responded to.
+
+## <a id="prometheusmanualrequires-all_units"></a>`all_units`
+
+.. deprecated:: 0.6.1
+   Use :attr:`all_joined_units` instead
+
+## <a id="prometheusmanualrequires-endpoint_name"></a>`endpoint_name`
+
+Relation name of this endpoint.
+
+## <a id="prometheusmanualrequires-is_joined"></a>`is_joined`
+
+Whether this endpoint has remote applications attached to it.
+
+## <a id="prometheusmanualrequires-jobs"></a>`jobs`
+
+Return a list of all jobs to be registered.
+
+## <a id="prometheusmanualrequires-joined"></a>`joined`
+
+.. deprecated:: 0.6.3
+   Use :attr:`is_joined` instead
+
+## <a id="prometheusmanualrequires-manage_flags"></a>`def manage_flags(self)`
+
+Method that subclasses can override to perform any flag management
+needed during startup.
+
+This will be called automatically after the framework-managed automatic
+flags have been updated.
+
+## <a id="prometheusmanualrequires-new_jobs"></a>`new_jobs`
+
+Return a list of new jobs to be registered.
+
+## <a id="prometheusmanualrequires-new_requests"></a>`new_requests`
+
+A list of requests which have not been responded.
+
+Requests should be handled by the charm and then responded to by
+calling ``request.respond(...)``.
+
+## <a id="prometheusmanualrequires-relations"></a>`relations`
+
+Collection of :class:`Relation` instances that are established for
+this :class:`Endpoint`.
+
+This is a :class:`KeyList`, so it can be iterated and indexed as a list,
+or you can look up relations by their ID.  For example::
+
+    rel0 = endpoint.relations[0]
+    assert rel0 is endpoint.relations[rel0.relation_id]
+    assert all(rel is endpoint.relations[rel.relation_id]
+               for rel in endpoint.relations)
+    print(', '.join(endpoint.relations.keys()))
+

--- a/interface.yaml
+++ b/interface.yaml
@@ -2,3 +2,5 @@ name: prometheus-manual
 summary: Interface for registering manual job definitions with Prometheus
 version: 1
 maintainer: "Cory Johns <cory.johns@canonical.com>"
+exclude:
+  - .docs

--- a/interface.yaml
+++ b/interface.yaml
@@ -1,0 +1,4 @@
+name: prometheus-manual
+summary: Interface for registering manual job definitions with Prometheus
+version: 1
+maintainer: "Cory Johns <cory.johns@canonical.com>"

--- a/provides.py
+++ b/provides.py
@@ -14,7 +14,7 @@ class PrometheusManualProvides(RequesterEndpoint):
         toggle_flag(self.expand_name('endpoint.{endpoint_name}.available'),
                     self.is_joined and self.requests)
 
-    def register_job(self, job_name, job_data, ca_cert=None):
+    def register_job(self, job_name, job_data, ca_cert=None, relation=None):
         """
         Register a manual job.
 
@@ -26,10 +26,14 @@ class PrometheusManualProvides(RequesterEndpoint):
         If a CA cert is given, the value of any ca_file field in the job data
         will be replaced with a filename after the CA cert data is written, so
         a placeholder value should be used.
+
+        If a specific relation is not given, the job will be registered with
+        every related Prometheus.
         """
         # we might be connected to multiple prometheuses for some strange
         # reason, so just send the job to all of them
-        for relation in self.relations:
+        relations = [relation] if relation is not None else self.relations
+        for relation in relations:
             JobRequest.create_or_update(match_fields=['job_name'],
                                         relation=relation,
                                         job_name=job_name,

--- a/provides.py
+++ b/provides.py
@@ -1,0 +1,37 @@
+from charms.reactive import (
+    toggle_flag,
+    RequesterEndpoint,
+)
+
+from .common import JobRequest
+
+
+class PrometheusManualProvides(RequesterEndpoint):
+    REQUEST_CLASS = JobRequest
+
+    def manage_flags(self):
+        super().manage_flags()
+        toggle_flag(self.expand_name('endpoint.{endpoint_name}.available'),
+                    self.is_joined and self.requests)
+
+    def register_job(self, job_name, job_data, ca_cert=None):
+        """
+        Register a manual job.
+
+        The job data should be the (unserialized) data defining the job.
+
+        To ensure uniqueness, a UUID will be added to the job name, and it will
+        be injected into the job data.
+
+        If a CA cert is given, the value of any ca_file field in the job data
+        will be replaced with a filename after the CA cert data is written, so
+        a placeholder value should be used.
+        """
+        # we might be connected to multiple prometheuses for some strange
+        # reason, so just send the job to all of them
+        for relation in self.relations:
+            JobRequest.create_or_update(match_fields=['job_name'],
+                                        relation=relation,
+                                        job_name=job_name,
+                                        job_data=job_data,
+                                        ca_cert=ca_cert)

--- a/requires.py
+++ b/requires.py
@@ -1,0 +1,31 @@
+from charms.reactive import (
+    toggle_flag,
+    ResponderEndpoint,
+)
+
+from .common import JobRequest
+
+
+class PrometheusManualRequires(ResponderEndpoint):
+    REQUEST_CLASS = JobRequest
+
+    def manage_flags(self):
+        super().manage_flags()
+        toggle_flag(self.expand_name('endpoint.{endpoint_name}.has_jobs'),
+                    self.is_joined and self.jobs)
+        toggle_flag(self.expand_name('endpoint.{endpoint_name}.new_jobs'),
+                    self.is_joined and self.new_jobs)
+
+    @property
+    def jobs(self):
+        """
+        Return a list of all jobs to be registered.
+        """
+        return self.all_requests
+
+    @property
+    def new_jobs(self):
+        """
+        Return a list of new jobs to be registered.
+        """
+        return self.new_requests


### PR DESCRIPTION
This allows charms to provide manual Prometheus scraper job configuration stanzas over the relation. Currently, this can only be done via charm config, which requires manual operator intervention. Manual job stanzas are required because the existing interface only supports very basic static target job types and none of the many Service Discovery type configurations that Prometheus supports.

Ideally, this interface would be extended with helper methods to construct specific SD type configurations without requiring the charm itself to know the exact syntax.

Depends on https://github.com/juju-solutions/charms.reactive/pull/215