### PR TITLE
Adding timestamp parameter for checking if request is latest

### DIFF
--- a/common.py
+++ b/common.py
@@ -18,6 +18,8 @@ class JobRequest(BaseRequest):
     job_data = Field('Config data for the job.')
 
     ca_cert = Field('Cert data for the CA used to validate connections.')
+    
+    timestamp = Field('Time that request created.')
 
     def to_json(self, ca_file=None):
         """

--- a/provides.py
+++ b/provides.py
@@ -14,7 +14,7 @@ class PrometheusManualProvides(RequesterEndpoint):
         toggle_flag(self.expand_name('endpoint.{endpoint_name}.available'),
                     self.is_joined and self.requests)
 
-    def register_job(self, job_name, job_data, ca_cert=None, relation=None):
+    def register_job(self, job_name, job_data, ca_cert=None, relation=None, timestamp=None):
         """
         Register a manual job.
 
@@ -38,4 +38,5 @@ class PrometheusManualProvides(RequesterEndpoint):
                                         relation=relation,
                                         job_name=job_name,
                                         job_data=job_data,
-                                        ca_cert=ca_cert)
+                                        ca_cert=ca_cert,
+                                        timestamp=timestamp)


### PR DESCRIPTION
Changing leader(e.g kube-master) doesn't trigger deletion of request data for
future usage. then prometheus write all of them to prometheus.yml file.
So adding timestamp & checking it on prometheus charm is one workaround.

[LP#1899706](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1899706)

I'm not sure this is correct way to fix it

e.g

in kubernetes-master charm
```python
def register_prometheus_jobs():
    prometheus = endpoint_from_flag('endpoint.prometheus.joined')
    tls = endpoint_from_flag('certificates.ca.available')
    monitoring_token = get_token('system:monitoring')
    timestamp = time.time()

    for relation in prometheus.relations:
        address, port = kubernetes_master.get_api_endpoint(relation)

        templates_dir = Path('templates')
        for job_file in Path('templates/prometheus').glob('*.yaml.j2'):
            prometheus.register_job(
                relation=relation,
                job_name=job_file.name.split('.')[0],
                timestamp=timestamp,
                job_data=yaml.safe_load(
                    render(source=str(job_file.relative_to(templates_dir)),
                           target=None,  # don't write file, just return data
                           context={
                               'k8s_api_address': address,
                               'k8s_api_port': port,
                               'k8s_token': monitoring_token,
                           })
                ),
                ca_cert=tls.root_ca_cert,
            )
```

and in prometheus code (rough)
```python
def update_prometheus_manual_jobs(manual_jobs):
    """Configure jobs shipped over relation."""
    job_jsons = []
    certs_dir = Path(PATHS["certs_dir"])
    certs_dir.mkdir(parents=True, exist_ok=True)
    time_tmp = 0
    for job in manual_jobs.jobs:
        if time_tmp < job.timestamp:
            job_jsons = []
            time_tmp = job.timestamp
        elif time_tmp > job.timestamp:
            continue
        if job.ca_cert:
            # escape path special chars to be safe when saving
            job_name = job.job_name.replace("/", "_")
            request_id = job.request_id.replace("/", "_")
            # escape glob special chars to be safe when cleaning up
            g_job_name = glob.escape(job_name)
            g_request_id = glob.escape(request_id)
            # include a hash of the cert data rather than just the request ID
            # so that check_reconfig_prometheus can detect changes to the data
            # via the filename
            cert_hash = sha1(job.ca_cert.encode("utf8")).hexdigest()
            cert_path = certs_dir / "{}-{}-{}.crt".format(
                job_name, request_id, cert_hash
            )
...
```
