### PR TITLE
Supporting app level relation data

### DIFF
--- a/common.py
+++ b/common.py
@@ -21,13 +21,9 @@ class JobRequest(BaseRequest):
 
     @classmethod
     def create(cls, relation, **fields):
-        request_id = fields.setdefault('request_id', fields['job_name'])
-        # pre-populate the field data directly in the data store (more
-        # efficient than calling _update_field for every field)
-        relation.to_publish['request_' + request_id] = fields
         relation.app = True
-        cls._cache[request_id] = cls(relation, request_id)
-        return cls._cache[request_id]
+        request_id = fields.setdefault('request_id', fields['job_name'])
+        super().create(relation, **fields)
 
     def to_json(self, ca_file=None):
         """

--- a/common.py
+++ b/common.py
@@ -22,7 +22,7 @@ class JobRequest(BaseRequest):
     @classmethod
     def create(cls, relation, **fields):
         relation.app = True
-        request_id = fields.setdefault('request_id', fields['job_name'])
+        fields.setdefault('request_id', fields['job_name'])
         super().create(relation, **fields)
 
     def to_json(self, ca_file=None):

--- a/common.py
+++ b/common.py
@@ -19,6 +19,16 @@ class JobRequest(BaseRequest):
 
     ca_cert = Field('Cert data for the CA used to validate connections.')
 
+    @classmethod
+    def create(cls, relation, **fields):
+        request_id = fields.setdefault('request_id', fields['job_name'])
+        # pre-populate the field data directly in the data store (more
+        # efficient than calling _update_field for every field)
+        relation.to_publish['request_' + request_id] = fields
+        relation.app = True
+        cls._cache[request_id] = cls(relation, request_id)
+        return cls._cache[request_id]
+
     def to_json(self, ca_file=None):
         """
         Render the job request to JSON string which can be included directly


### PR DESCRIPTION
k-m register unit relation data currently, so now when leader changed,

prometheus takes several duplicated manual-job from them.

so I wanted to use application level relation data but I needed to change charmhelpers, charms.reactive

https://github.com/juju/charm-helpers/pull/566/files

https://github.com/juju-solutions/charms.reactive/pull/232/files