### PR TITLE
Client cert and key

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Configuration Docs][].  The job configuration will be included as an item
 under `scrape_configs` largely unchanged, except for two things:
 
 * To ensure uniqueness, the provided job name will have a UUID appended to it.
-* Because the CA cert must be written to disk separately from the config, any
-  `tls_config` sections will have their `ca_file` field values replaced with
-  the path to the file where the provided `ca_cert` data is written.
+* Because the CA cert, client cert and key must be written to disk separately
+  from the config, any `tls_config` sections will have their `ca_file`,
+  `cert_file` and `key_file` field values replaced with the path to the file
+  where the provided `ca_cert`, `client_cert` and `client_key` data is written
+  respectively.
 
 # Example Usage
 
@@ -107,7 +109,6 @@ def register_prometheus_jobs():
 # Contact Information
 
 Maintainer: Cory Johns &lt;Cory.Johns@canonical.com&gt;
-
 
 [Juju]: https://jujucharms.com
 [Prometheus Configuration Docs]: https://prometheus.io/docs/prometheus/latest/configuration/configuration/

--- a/docs/common.md
+++ b/docs/common.md
@@ -44,13 +44,23 @@ Whether this request was received by the other side of the relation.
 Acknowledge this request, and indicate success or failure with an
 optional explanation.
 
-## <a id="jobrequest-to_json"></a>`def to_json(self)`
+## <a id="jobrequest-to_json"></a>`def to_json(self, ca_file=None, cert_file=None, key_file=None)`
 
 Render the job request to JSON string which can be included directly
 into Prometheus config.
 
 Keys will be sorted in the rendering to ensure a stable ordering for
 comparisons to detect changes.
+
+If `ca_file` is given, it will be used to replace the value of any
+`ca_file` fields in the job.
+
+If `cert_file` and `key_file` are given, they will be used to replace
+the value of any `cert_file` and `key_file` fields in the job.
+
+The charm should ensure that the request's `ca_cert`, `client_cert`
+and `client_key` data is writen to those paths prior to calling this
+method.
 
 # <a id="jobresponse"></a>`class JobResponse(BaseResponse)`
 
@@ -59,4 +69,3 @@ Base class for responses using the request / response pattern.
 ## <a id="jobresponse-fromkeys"></a>`None`
 
 Returns a new dict with keys from iterable and values equal to value.
-

--- a/docs/provides.md
+++ b/docs/provides.md
@@ -82,7 +82,7 @@ needed during startup.
 This will be called automatically after the framework-managed automatic
 flags have been updated.
 
-## <a id="prometheusmanualprovides-register_job"></a>`def register_job(self, job_name, job_data, ca_cert=None)`
+## <a id="prometheusmanualprovides-register_job"></a>`def register_job(self, job_name, job_data, ca_cert=None, client_cert=None, client_key=None)`
 
 Register a manual job.
 
@@ -94,6 +94,10 @@ be injected into the job data.
 If a CA cert is given, the value of any ca_file field in the job data
 will be replaced with a filename after the CA cert data is written, so
 a placeholder value should be used.
+
+If a client cert and key are given, the value of any cert_file/key_file
+fields in the job data will be replaced with filenames pointing to the
+corresponding files after there data is written.
 
 ## <a id="prometheusmanualprovides-relations"></a>`relations`
 
@@ -116,4 +120,3 @@ A list of all requests which have been submitted.
 ## <a id="prometheusmanualprovides-responses"></a>`responses`
 
 A list of all responses which have been received.
-

--- a/provides.py
+++ b/provides.py
@@ -14,7 +14,15 @@ class PrometheusManualProvides(RequesterEndpoint):
         toggle_flag(self.expand_name('endpoint.{endpoint_name}.available'),
                     self.is_joined and self.requests)
 
-    def register_job(self, job_name, job_data, ca_cert=None, relation=None):
+    def register_job(
+        self,
+        job_name,
+        job_data,
+        ca_cert=None,
+        client_cert=None,
+        client_key=None,
+        relation=None,
+    ):
         """
         Register a manual job.
 
@@ -27,6 +35,10 @@ class PrometheusManualProvides(RequesterEndpoint):
         will be replaced with a filename after the CA cert data is written, so
         a placeholder value should be used.
 
+        If a client cert and key are given, the value of any cert_file/key_file
+        fields in the job data will be replaced with filenames pointing to the
+        corresponding files after there data is written.
+
         If a specific relation is not given, the job will be registered with
         every related Prometheus.
         """
@@ -38,4 +50,6 @@ class PrometheusManualProvides(RequesterEndpoint):
                                         relation=relation,
                                         job_name=job_name,
                                         job_data=job_data,
-                                        ca_cert=ca_cert)
+                                        ca_cert=ca_cert,
+                                        client_cert=client_cert,
+                                        client_key=client_key)


### PR DESCRIPTION
This allows a related unit to provide a client cert and key. This is needed to have prometheus scrape LXD metrics endpoint that requires TLS client authentication (see https://linuxcontainers.org/lxd/docs/master/metrics/).