### PR TITLE
Using app relation data instead of unit relation data

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -3,11 +3,8 @@ from charms.reactive import (
     RequesterEndpoint,
 )
 
-from .common import JobRequest
-
 
 class PrometheusManualProvides(RequesterEndpoint):
-    REQUEST_CLASS = JobRequest
 
     def manage_flags(self):
         super().manage_flags()
@@ -46,10 +43,11 @@ class PrometheusManualProvides(RequesterEndpoint):
         # reason, so just send the job to all of them
         relations = [relation] if relation is not None else self.relations
         for relation in relations:
-            JobRequest.create_or_update(match_fields=['job_name'],
-                                        relation=relation,
-                                        job_name=job_name,
-                                        job_data=job_data,
-                                        ca_cert=ca_cert,
-                                        client_cert=client_cert,
-                                        client_key=client_key)
+            relation.to_publish_app['job_'+job_name] = {
+                'job_name': job_name,
+                'job_data': job_data,
+                'ca_cert': ca_cert,
+                'client_cert': client_cert,
+                'client_key': client_key
+            }
+            relation._flush_data()

--- a/provides.py
+++ b/provides.py
@@ -1,15 +1,16 @@
 from charms.reactive import (
     toggle_flag,
-    RequesterEndpoint,
+    Endpoint,
 )
 
 
-class PrometheusManualProvides(RequesterEndpoint):
+class PrometheusManualProvides(Endpoint):
 
     def manage_flags(self):
         super().manage_flags()
         toggle_flag(self.expand_name('endpoint.{endpoint_name}.available'),
-                    self.is_joined and self.requests)
+                    self.is_joined)
+                    #self.is_joined and self.requests)
 
     def register_job(
         self,

--- a/requires.py
+++ b/requires.py
@@ -1,31 +1,92 @@
 from charms.reactive import (
     toggle_flag,
-    ResponderEndpoint,
+    Endpoint,
 )
 
-from .common import JobRequest
+import json
+from copy import deepcopy
+from uuid import uuid4
+
+class Job(object):
+
+    def __init__(self, dic):
+        for key in dic:
+            setattr(self, key, dic[key])
 
 
-class PrometheusManualRequires(ResponderEndpoint):
-    REQUEST_CLASS = JobRequest
+    def to_json(self, ca_file=None, cert_file=None, key_file=None):
+        """
+        Render the job request to JSON string which can be included directly
+        into Prometheus config.
+        Keys will be sorted in the rendering to ensure a stable ordering for
+        comparisons to detect changes.
+        If `ca_file` is given, it will be used to replace the value of any
+        `ca_file` fields in the job.
+        If `cert_file` and `key_file` are given, they will be used to replace
+        the value of any `cert_file` and `key_file` fields in the job.
+        The charm should ensure that the request's `ca_cert`, `client_cert`
+        and `client_key` data is writen to those paths prior to calling this
+        method.
+        """
+        job_data = deepcopy(self.job_data)  # make a copy we can modify
+        job_data['job_name'] = '{}-{}'.format(self.job_name, self.request_id)
+
+        if ca_file:
+            for key, value in job_data.items():
+                # update the cert path at the job level
+                if key == 'tls_config':
+                    value['ca_file'] = str(ca_file)
+
+                # update the cert path at the SD config level
+                if key.endswith('_sd_configs'):
+                    for sd_config in value:
+                        sd_tls_config = sd_config.get('tls_config', {})
+                        if not sd_tls_config:
+                            continue
+                        if 'ca_file' in sd_tls_config:
+                            sd_tls_config['ca_file'] = str(ca_file)
+
+        if cert_file and key_file:
+            for key, value in job_data.items():
+                # update the cert/key paths at the job level
+                if key == 'tls_config':
+                    value['cert_file'] = str(cert_file)
+                    value['key_file'] = str(key_file)
+
+                # update the cert/key paths at the SD config level
+                if key.endswith('_sd_configs'):
+                    for sd_config in value:
+                        sd_tls_config = sd_config.get('tls_config', {})
+                        if not sd_tls_config:
+                            continue
+                        if 'client_file' in sd_tls_config:
+                            sd_tls_config['cert_file'] = str(cert_file)
+                        elif 'key_file' in sd_tls_config:
+                            sd_tls_config['key_file'] = str(key_file)
+
+        return json.dumps(job_data, sort_keys=True)
+
+
+class PrometheusManualRequires(Endpoint):
 
     def manage_flags(self):
         super().manage_flags()
         toggle_flag(self.expand_name('endpoint.{endpoint_name}.has_jobs'),
                     self.is_joined and self.jobs)
         toggle_flag(self.expand_name('endpoint.{endpoint_name}.new_jobs'),
-                    self.is_joined and self.new_jobs)
+                    self.is_joined and self.jobs)
 
     @property
     def jobs(self):
         """
         Return a list of all jobs to be registered.
         """
-        return self.all_requests
+        ret = []
+        for job in self.relations[0].received_app.values():
+            if type(job) != dict:
+                continue
+            # dummy request_id
+            job['request_id'] = str(uuid4())
+            ret.append(Job(job))
 
-    @property
-    def new_jobs(self):
-        """
-        Return a list of new jobs to be registered.
-        """
-        return self.new_requests
+        return ret

--- a/requires.py
+++ b/requires.py
@@ -13,7 +13,8 @@ class Job(object):
         for key in dic:
             setattr(self, key, dic[key])
 
-
+    # seyeong kim : I moved this code from request_reponse pattern as
+    # compatibility
     def to_json(self, ca_file=None, cert_file=None, key_file=None):
         """
         Render the job request to JSON string which can be included directly
@@ -79,7 +80,8 @@ class PrometheusManualRequires(Endpoint):
     @property
     def jobs(self):
         """
-        Return a list of all jobs to be registered.
+        Return a list of all jobs to be registered by using application
+        relation data
         """
         ret = []
         for job in self.relations[0].received_app.values():


### PR DESCRIPTION
As LP:1899706, solution for the issue is using application relation data instead of unit relation data.

This fix needs latest charms.reactive and charmhelpers.

This fix abandons request-reponse pattern which looks like use only for this.
johnca mentioned this in [2]

I know this code may not good enough.

Any advices are welcome.

Thanks.

[1] https://bugs.launchpad.net/charm-kubernetes-master/+bug/1899706
[2] https://github.com/juju-solutions/charms.reactive/commit/92a8ee4c74781568a3e3e03c8f007ed6597c61cb